### PR TITLE
Fix LocalTuyaLight brightness mapping

### DIFF
--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -98,10 +98,8 @@ def map_range(value, from_lower, from_upper, to_lower=0, to_upper=255, reverse=F
     """Map a value in one range to another."""
     if reverse:
         value = from_upper - value + from_lower
-    mapped = (value - from_lower) * (to_upper - to_lower) / (
-        from_upper - from_lower
-    ) + to_lower
-    return round(min(max(mapped, to_lower), to_upper))
+    mapped = value * to_upper / from_upper
+    return min(max(round(mapped), to_lower), to_upper)
 
 
 def flow_schema(dps):

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -186,9 +186,15 @@ class LocalTuyaLight(LocalTuyaEntity, LightEntity):
     @property
     def brightness(self):
         """Return the brightness of the light."""
-        if self._brightness is not None and (self.is_color_mode or self.is_white_mode):
+        brightness = self._brightness
+        if brightness is not None and (self.is_color_mode or self.is_white_mode):
+            if self._upper_brightness >= 1000: 
+                # Round to the nearest 10th, since Tuya does that.
+                # If the value is less than 5, it will round down to 0.
+                # So instead, we take _lower_brightness, which is < 5 in this case.
+                brightness = (brightness + 5) // 10 * 10 if brightness >= 5 else self._lower_brightness
             return map_range(
-                self._brightness, self._lower_brightness, self._upper_brightness, 0, 255
+                brightness, self._lower_brightness, self._upper_brightness, 0, 255
             )
         return None
 


### PR DESCRIPTION
**Brief:**
The minimum brightness value does not create a "range": it is only a limitation, e.g. by device capabilities. The range to be mapped is still (0, maximum). This also maps percentages to equal values between ranges.

**Long:**
HA UI for a Light entity provides brightness change slider expressed in percents. Actually, it does not allow to set 0%: the range is 1-100%. In automation and scripts, setting the brightness value to 0 is equal to turning off. This proves the concept that the minimum valuehas a special meaning, but not creates a "range".

With the  current brightness mapping, the percentage values are different in HA and SmartLife in 50 out of 100 cases. With the provided mapping, the percentage values are always equal.

I found only local use of `map_range`, and no use of `reverse` parameter.